### PR TITLE
Apply Swaptoshi's Patch for Klayr-SDK: registerModulePriority, fee module enhancement, nft module metadata

### DIFF
--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -248,6 +248,10 @@ export class Application {
 		this._registerModule(Module);
 	}
 
+	public registerModulePriority(Module: BaseModule): void {
+		this._registerModulePriority(Module);
+	}
+
 	public registerInteroperableModule(interoperableModule: BaseInteroperableModule) {
 		const interoperabilityModule = this._registeredModules.find(
 			module => module.name === MODULE_NAME_INTEROPERABILITY,
@@ -385,6 +389,16 @@ export class Application {
 		}
 		this._registeredModules.push(mod);
 		this._stateMachine.registerModule(mod);
+		this._controller.registerEndpoint(mod.name, getEndpointHandlers(mod.endpoint));
+	}
+
+	private _registerModulePriority(mod: BaseModule): void {
+		assert(mod, 'Module implementation is required');
+		if (Object.keys(this._controller.getRegisteredPlugins()).includes(mod.name)) {
+			throw new Error(`A plugin with name "${mod.name}" is already registered.`);
+		}
+		this._registeredModules.unshift(mod);
+		this._stateMachine.registerModulePriority(mod);
 		this._controller.registerEndpoint(mod.name, getEndpointHandlers(mod.endpoint));
 	}
 

--- a/framework/src/modules/fee/method.ts
+++ b/framework/src/modules/fee/method.ts
@@ -30,6 +30,10 @@ export class FeeMethod extends BaseMethod {
 		return this._config.feeTokenID;
 	}
 
+	public getConfig() {
+		return this._config;
+	}
+
 	public payFee(methodContext: MethodContext, amount: bigint): void {
 		const isCCMProcessing = getContextStoreBool(
 			methodContext.contextStore,

--- a/framework/src/modules/fee/types.ts
+++ b/framework/src/modules/fee/types.ts
@@ -23,6 +23,8 @@ export interface ModuleConfig {
 	minFeePerByte: number;
 	maxBlockHeightZeroFeePerByte: number;
 	feePoolAddress?: Buffer;
+	dangerouslySkipBalanceVerification?: boolean;
+	dangerouslySkipAvailableFeeInitialization?: boolean;
 }
 
 export type ModuleConfigJSON = JSONObject<ModuleConfig>;

--- a/framework/src/modules/nft/module.ts
+++ b/framework/src/modules/nft/module.ts
@@ -227,7 +227,12 @@ export class NFTModule extends BaseInteroperableModule {
 					response: isNFTSupportedResponseSchema,
 				},
 			],
-			assets: [],
+			assets: [
+				{
+					version: 0,
+					data: genesisNFTStoreSchema,
+				},
+			],
 		};
 	}
 

--- a/framework/src/state_machine/state_machine.ts
+++ b/framework/src/state_machine/state_machine.ts
@@ -37,6 +37,11 @@ export class StateMachine {
 		this._modules.push(mod);
 	}
 
+	public registerModulePriority(mod: BaseModule): void {
+		this._validateExisting(mod);
+		this._modules.unshift(mod);
+	}
+
 	public async init(
 		logger: Logger,
 		genesisConfig: GenesisConfig,


### PR DESCRIPTION
### What was the problem?  

1. Modules like Swaptoshi's `feeConversion` and the `governance` module required a way to explicitly set their execution priority.  
2. The Fee module needed enhancements to support features like configuration retrieval and better compatibility with custom modules handling balance verification and fee initialization.  
3. The NFT module lacked functionality to index genesis assets in the service middleware.  

### How was it solved?  

1. **Module Registration Priority**  

   - Added `registerModulePriority` in `framework/src/application.ts` and `framework/src/state_machine/state_machine.ts`.  
   - Implemented a priority-based registration system using an `unshift` logic to ensure custom modules are executed first.  

2. **Fee Module Enhancements**  

   - Introduced the `getConfig` method in `framework/src/modules/fee/method.ts` to allow retrieval of fee configurations by other modules.  
   - Added new configuration options `dangerouslySkipBalanceVerification` and `dangerouslySkipAvailableFeeInitialization` in `framework/src/modules/fee/module.ts` and `framework/src/modules/fee/types.ts`. These options improve compatibility with custom modules managing these processes independently.  Since the default value for both is `false`, they will not affect the behavior of other modules.

3. **NFT Module Enhancements**  

   - Updated `framework/src/modules/nft/assets.ts` to include `genesisNFTStoreSchema` in the assets metadata. This addition supports indexing genesis assets in the service middleware.  

### How was it tested?  

The changes were integrated into **Swaptoshi-Core** and tested end-to-end (E2E) directly, to verify:  
- The module registration priority mechanism works correctly for critical modules like `feeConversion` and `governance`.  
- The `getConfig` method successfully retrieves fee configurations, ensuring compatibility with the `feeConversion` module.  
- The new Fee module configurations (`dangerouslySkipBalanceVerification` and `dangerouslySkipAvailableFeeInitialization`) integrate smoothly with custom modules.  
- The `genesisNFTStoreSchema` addition enables accurate indexing of genesis assets in the service middleware.  